### PR TITLE
Bump browserify peerDependency to < 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/justinjmoses/casify/issues"
   },
   "peerDependencies": {
-    "browserify": ">= 2.3.0 < 9"
+    "browserify": ">= 2.3.0 < 11"
   },
   "homepage": "https://github.com/justinjmoses/casify",
   "dependencies": {


### PR DESCRIPTION
The tests pass and a local example works as expected with Browserify @10.2.4. 
